### PR TITLE
Fix html issues and add update function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ In order to access Templates, add the following code snippet just before the las
 
 `<?php include("template/sidebar.php");?>`
 
+### Add rule to .htaccess
+
+Add the following to the end of the '.htaccess' file located in the sendy folder.
+
+`# template
+RewriteRule ^templates/(.*)$ templates.php?i=$1 [L]`
+
 ### Complete! 
 
 You can now create templates in Sendy!

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Firstly, make a copy of the 'create.php' that already exists in your Sendy insta
 
 In order to access Templates, add the following code snippet just before the last closing DIV in 'sidebar.php' located in '/includes/'
 
-    <?php include("template/sidebar.php");?>`
+    <?php include("template/sidebar.php");?>
 
 ### Add rule to .htaccess
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Templates for Sendy
 ===========
 
-**Version: 1.0.0**
+**Version: 1.0.1**
 
 > **Create and save HTML templates in Sendy to use in campaigns.**
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Firstly, make a copy of the 'create.php' that already exists in your Sendy insta
 
 In order to access Templates, add the following code snippet just before the last closing DIV in 'sidebar.php' located in '/includes/'
 
-`<?php include("template/sidebar.php");?>`
+    <?php include("template/sidebar.php");?>`
 
 ### Add rule to .htaccess
 
 Add the following to the end of the '.htaccess' file located in the sendy folder.
 
-`# template
-RewriteRule ^templates/(.*)$ templates.php?i=$1 [L]`
+    # template
+    RewriteRule ^templates/(.*)$ templates.php?i=$1 [L]
 
 ### Complete! 
 

--- a/install.sql
+++ b/install.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `templates` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
-  `content` blob NOT NULL,
+  `content` mediumtext NOT NULL,
   `active` tinyint(1) NOT NULL DEFAULT '1',
   `uid` int(11) NOT NULL,
   PRIMARY KEY (`id`)

--- a/template/edit-template.php
+++ b/template/edit-template.php
@@ -19,7 +19,7 @@
 	    	<h2>Editing: <i><?php echo $tname;?></i></h2><br/>
     	</div>
     	<div class="row-fluid">
-    		<form action="<?php echo get_app_info('path')?>/includes/create/update-template.php?i=<?php echo get_app_info('app')?>" method="POST" accept-charset="utf-8" class="form-vertical" id="edit-form" enctype="multipart/form-data">
+    		<form action="<?php echo get_app_info('path')?>/template/update-template.php?i=<?php echo get_app_info('app')?>" method="POST" accept-charset="utf-8" class="form-vertical" id="edit-form" enctype="multipart/form-data">
 			    <div class="span3">
 				    
 			    	<label class="control-label" for="name">Template Name</label>

--- a/template/save-template.php
+++ b/template/save-template.php
@@ -1,7 +1,9 @@
 <?php include('../includes/functions.php');?>
 <?php include('../includes/login/auth.php');?>
 <?php
-	$templateHtml = mysqli_real_escape_string($mysqli, $_POST['html']);
+	$templateHtml = stripslashes($_POST['html']);
+	if(trim($templateHtml)=='<html><head></head><body></body></html>') $templateHtml = '';
+    $templateHtml = addslashes($templateHtml);
 	$templateName = mysqli_real_escape_string($mysqli, $_POST['name']);
 	$app = mysqli_real_escape_string($mysqli, $_POST['id']);
 	

--- a/template/update-template.php
+++ b/template/update-template.php
@@ -1,0 +1,15 @@
+<?php include('../includes/functions.php');?>
+<?php include('../includes/login/auth.php');?>
+<?php
+	$templateHtml = stripslashes($_POST['html']);
+	if(trim($templateHtml)=='<html><head></head><body></body></html>') $templateHtml = '';
+    $templateHtml = addslashes($templateHtml);
+	$templateName = mysqli_real_escape_string($mysqli, $_POST['name']);
+	$app = mysqli_real_escape_string($mysqli, $_POST['id']);
+	$tid = mysqli_real_escape_string($mysqli, $_POST['tid']);
+	
+	$q = 'UPDATE templates SET name="'.$templateName.'", content="'.$templateHtml . '" WHERE uid="'. $app .'" AND id="'. $tid .'"';
+	$r = mysqli_query($mysqli, $q);
+	header("Location:".get_app_info('path').'/templates?i='.$app); 
+
+?>


### PR DESCRIPTION
Previously HTML was invalid when re-opening the template as the entries from mysqli_real_escape_string() were not reverted.
- Modified so that the templates are stored/saved in the same format as Sendy uses for campaigns.
- Fixed update functionality which previously resulted in a 404.

If upgrading from v1.0.0, you'll have to change your table structure from blob to medium text for 'content'.
